### PR TITLE
Allow single quotes in symbol names

### DIFF
--- a/resources/parsers/Clojure.g4
+++ b/resources/parsers/Clojure.g4
@@ -262,6 +262,7 @@ SYMBOL_REST
     : SYMBOL_HEAD
     | '0'..'9'
     | '.'
+    | '\''
     ;
 
 // Whitespace, Comments


### PR DESCRIPTION
Symbol names like `my-thing'` are valid in clojure. Single quote cannot start a symbol, but can be anywhere else.